### PR TITLE
Update .gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/libopencm3/libopencm3.git
 [submodule "inc/FreeRTOS"]
 	path = inc/FreeRTOS
-	url = git@github.com:FreeRTOS/FreeRTOS-Kernel.git
+	url = https://github.com/FreeRTOS/FreeRTOS-Kernel.git


### PR DESCRIPTION
When no SSH key is setup, updating submodules results in the following error:
git@github.com: Permission denied (publickey).
fatal: Could not read from remote repository.
This can be avoided by using HTTPS instead.